### PR TITLE
Cleanup in `app.d` and `parser.d`

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -18,19 +18,19 @@ struct CLInput
     }
 
     static CLInput parseCommands(string[] args) 
-    {	
+    {    
         CLInput res = CLInput.defaults();
-    	arraySep = ",";
+        arraySep = ",";
         try
         {
-        	auto optRes = getopt(
+            auto optRes = getopt(
                 args,
                 config.bundling,
-        	    "run|r", &res.runPostCompile,
-        	    "output|o", &res.fileOut,
+                "run|r", &res.runPostCompile,
+                "output|o", &res.fileOut,
                 config.required, 
-        	    "files|file|f", &res.filesIn,
-        	);
+                "files|file|f", &res.filesIn,
+            );
             if (optRes.helpWanted)
             {
               usage(args[0]);
@@ -40,7 +40,7 @@ struct CLInput
         catch (GetOptException e)
         {
             usage(args[0]);
-            writeln(e.msg);
+            writeln("Error: ", e.msg);
             exit(1);
         }
         return res;
@@ -72,33 +72,33 @@ const string BINARY_FILE = "fkl";
 void main(string[] args) 
 {    
     auto clin = CLInput.parseCommands(args);
-    bool valid = areFilesInvalid(clin);
-    if(valid)
-    {
-    	setFiles(clin.filesIn);
-    	parseFiles();
-    }
+    validateInput(clin);
+    parseFiles(clin.filesIn);
 }
 
-bool areFilesInvalid(CLInput clin)
-{
-	bool invalidInFiles = false;
+void validateInput(CLInput clin)
+in {
+     /* there is a bug in CLInput.parseCommands
+        if clin.filesIn is empty. */
+     assert(clin.filesIn.length > 0); 
+} do { 
+    // TODO: consider using map-reduce here to validate
+    // rather than manual for loop for cleaner code
+    bool invalidInFiles = false;
     foreach (string f; clin.filesIn) 
     {
         string ext = split(f, ".")[1];
-        if(ext != SOURCE_FILE) 
+        if (ext != SOURCE_FILE) 
         {
             invalidInFiles = true;
             break;
         }
     }
-    if(invalidInFiles || clin.filesIn.length == 0) 
+    if (invalidInFiles)  
     {
-        writeln("Error: Please provide either a .fkl binary or at least one .fic script file.");
-        return false;
+        writeln("Error: Invalid input file(s): please provide a `.fic` fickle source file.");
+        exit(1); 
     }
-    writeln(clin);
-    return true;
 }
 
 

--- a/source/app.d
+++ b/source/app.d
@@ -74,7 +74,7 @@ const string BINARY_FILE = "fkl";
 void main(string[] args) 
 {    
     auto clin = CLInput.parseCommands(args);
-    parseFiles(clin.filesIn);
+    Script[] scripts = parseFiles(clin.filesIn);
 }
 
 

--- a/source/app.d
+++ b/source/app.d
@@ -76,6 +76,20 @@ void main(string[] args)
     parseFiles(clin.filesIn);
 }
 
+
+/*
+ * TODO: consider removing this function.
+ * checking if the file extension is correct
+ * may not be a good behavior. for example,
+ * if someone were to make a fickle source
+ * file with a shebang into an executable, 
+ * they would likely remove the extension.
+ * generally, extensions should be seen as
+ * annotations/suggestions rather than rules. 
+ * if a `.txt` file's content is valid
+ * fickle source, should we reject to compile it?
+ * maybe remove this? maybe add a flag to disable it?
+ */
 void validateInput(CLInput clin)
 in {
      /* there is a bug in CLInput.parseCommands

--- a/source/app.d
+++ b/source/app.d
@@ -31,11 +31,6 @@ struct CLInput
                 config.required, 
                 "files|file|f", &res.filesIn,
             );
-            if (optRes.helpWanted)
-            {
-              usage(args[0]);
-              exit(0);
-            }
         }
         catch (GetOptException e)
         {
@@ -43,6 +38,12 @@ struct CLInput
             writeln("Error: ", e.msg);
             exit(1);
         }
+        if (optRes.helpWanted)
+        {
+          usage(args[0]);
+          exit(0);
+        }
+ 
         validateInput(clin);
         return res;
     }

--- a/source/app.d
+++ b/source/app.d
@@ -43,6 +43,7 @@ struct CLInput
             writeln("Error: ", e.msg);
             exit(1);
         }
+        validateInput(clin);
         return res;
     }
 }
@@ -72,7 +73,6 @@ const string BINARY_FILE = "fkl";
 void main(string[] args) 
 {    
     auto clin = CLInput.parseCommands(args);
-    validateInput(clin);
     parseFiles(clin.filesIn);
 }
 

--- a/source/parsing/parser.d
+++ b/source/parsing/parser.d
@@ -7,30 +7,22 @@ import std.typecons;
 import std.algorithm;
 import std.array;
 
-import parsing.tokens;
+import parsing.tokentype;
 
 alias CodeBlock = Tuple!(string, "name", int, "startLine", int, "endLine");
 
-string[] files;
-
-void setFiles(string[] f)
+Script[] parseFiles(string[] files)
 {
-    files = f;
-}
-
-void printFiles()
-{
-    writefln(format("%s", files));
-}
-
-void parseFiles()
-{
-    Script s = Script(files[0], true);
-    writefln(format("has subroutine: %s, subroutine count: %s, subroutines: %s", 
-        s.hasSubroutines, s.subroutine_count, s.subroutines));
+    Script[] acc = [];
+    acc ~= Script(files[0], true); 
+    /* TODO: add to specification and documentation that 
+       first file provided is assumed to be main file */
+    files.remove(0);
+    foreach (string file; files) {
+        acc ~= Script(file, false);
+    }
+    return acc;
     
-    writefln(format("%s", TokenTypes.NULL.id));
-    writeln(TokenTypes.NULL);
 }
 
 struct Script


### PR DESCRIPTION
### `app.d`:
- replaced `bool areFilesInvalid(CLInput clin)` with `void validateInput(CLInput clin)`. Instead of returning false, the function reports an error and exits. Changed name for forwards compatibility in case other command line input needs to be validated.
- Added a TODO concerning file extensions, and whether we really should enforce them or not and some things to think about.
- moved validation step (call of `validateInput`) into `CLInput.parseCommands()`. It felt inappropriate to have it in `main`.
- Fixed a logic error in `CLInput.parseCommands()`: I had an `exit()` in a `try`/`catch`. Though this may work, it felt wrong and I don't like it. so I changed it 👍
- because `parseFiles` was changed to have return type `Script[]` rather than type `void`, I saved its result into a variable.
### `parser.d`
- the `files` global variable and `setFiles` setter weren't needed. I removed them in favor of passing the files into `parseFiles` directly.
- removed some extra debug print statements.
 


