### PR TITLE
Patch Tokenizer bug and add Word Literals

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -20,10 +20,11 @@ struct CLInput
     static CLInput parseCommands(string[] args) 
     {    
         CLInput res = CLInput.defaults();
+        GetoptResult optRes; 
         arraySep = ",";
         try
         {
-            auto optRes = getopt(
+            optRes = getopt(
                 args,
                 config.bundling,
                 "run|r", &res.runPostCompile,
@@ -44,7 +45,7 @@ struct CLInput
           exit(0);
         }
  
-        validateInput(clin);
+        validateInput(res);
         return res;
     }
 }
@@ -74,7 +75,11 @@ const string BINARY_FILE = "fkl";
 void main(string[] args) 
 {    
     auto clin = CLInput.parseCommands(args);
+    writeln(clin);
     Script[] scripts = parseFiles(clin.filesIn);
+    writeln(scripts);
+    Token[] tokens = tokenizeScript(scripts[0]);
+    writeln(tokens);
 }
 
 

--- a/source/parsing/tokenizer.d
+++ b/source/parsing/tokenizer.d
@@ -3,6 +3,8 @@ module parsing.tokenizer;
 import std.algorithm;
 import std.uni;
 import std.stdio;
+import std.conv;
+import std.stdint;
 
 import parsing.tokentype;
 import parsing.parser;
@@ -34,6 +36,19 @@ struct Token
         this.loc = loc;
         this.type = type;
         this.value = value;
+    }
+}
+
+bool isWordLiteral(string s) 
+{
+    try
+    {
+        s.parse!int16_t();
+        return true;
+    } 
+    catch (ConvException e)
+    {
+        return false;
     }
 }
 
@@ -124,6 +139,11 @@ public Token[] tokenizeScript(Script script)
             {
                 switch(current)
                 {
+                    case "":
+                        /* multiple whitespace in succession
+                           generates empty `current`, skip
+                           these cases */
+                        break;
                     case MAIN_START:
                         tokens ~= Token(
                             line, cha-MAIN_START.length-1, cha-1, 
@@ -151,6 +171,13 @@ public Token[] tokenizeScript(Script script)
                                 line, cha-current.length-1, cha-1,
                                 TokenTypes.INTRINSIC_CALL, current);
                         }
+                        else if (isWordLiteral(current))
+                        {
+                            tokens ~= Token(
+                                line, cha-current.length-1, cha-1,
+                                TokenTypes.WORD_LITERAL, current);
+                        }
+                        /* TODO: Add elifs here to handle multi-char tokens. */
                         else 
                         {
                             writefln("Error: unrecognized token %s", current);

--- a/source/parsing/tokenizer.d
+++ b/source/parsing/tokenizer.d
@@ -1,12 +1,13 @@
 module parsing.tokenizer;
 
 import std.algorithm;
-import std.ascii;
+import std.uni;
+import std.stdio;
 
 import parsing.tokentype;
 import parsing.parser;
 
-const string MAIN_START = " fic";
+const string MAIN_START = "fic";
 const string MAIN_END = "kle";
 const string SUBR_DEF = "def";
 const string INC_BUILTIN = "inc";
@@ -56,7 +57,19 @@ public Token[] tokenizeScript(Script script)
     
     for(int line = 0; line < script.lines; line++)
     {
-        auto currentline = script.fileContent[line];
+       auto currentline = script.fileContent[line];
+       currentline ~= " "; 
+        /* append a space to the end of the line. this 
+           is a dirty patch for a a bug we have here. 
+           as we go through the characters in a line, we
+           only collect multi-character tokens after finding
+           whitespace. if a multi-character token is not
+           followed by whitespace (is the case at the 
+           end of the line, because \n is removed somewhere
+           in the process of getting `fileContent`.)
+          
+           BUG: collecting multichar tokens fails at EOL
+        */
         string current = "";
 
         for(int cha = 0; cha < currentline.length; cha++)
@@ -137,6 +150,10 @@ public Token[] tokenizeScript(Script script)
                             tokens ~= Token(
                                 line, cha-current.length-1, cha-1,
                                 TokenTypes.INTRINSIC_CALL, current);
+                        }
+                        else 
+                        {
+                            writefln("Error: unrecognized token %s", current);
                         }
                         break;
 


### PR DESCRIPTION
There's a bug in the tokenizer that makes it treat end of line tokens incorrectly. I patched it, but I'm not sure if it's a good long-term solution. I put a big comment in there explaining it. I think we can worry about it later and just rely on the patch for now. I also added word literals! I also fixed up app.d and made it print a bunch of debug/testing info.